### PR TITLE
Add Cookiejuce template

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -14,7 +14,7 @@ https://github.com/adamski/stk_wrapper JUCE wrapper module for the Synthesis Too
 https://github.com/dar-io-p/PotenzaDSP Collection of simple workflow plugins and UI modules
 
 ## Templates
-https://github.com/madskjeldgaard/Cookiejuce Generate JUCE projects from the command line using cookiecutter. C++20, CMake, CLAP and CPM. Based on Pamplejuce.
+https://github.com/madskjeldgaard/Cookiejuce Generate JUCE projects from the command line using cookiecutter. C++20, CMake, CLAP and CPM. Based on Pamplejuce
 https://github.com/sudara/pamplejuce C++20, JUCE, CMake, Catch2, Pluginval on GitHub Actions
 https://github.com/eyalamirmusic/JUCECmakeRepoPrototype Large variety of JUCE and CMake plugin and app templates
 https://github.com/maxwellpollack/juce-plugin-ci (Archived) CI for JUCE audio plugins with GitHub Actions

--- a/sites.txt
+++ b/sites.txt
@@ -14,7 +14,7 @@ https://github.com/adamski/stk_wrapper JUCE wrapper module for the Synthesis Too
 https://github.com/dar-io-p/PotenzaDSP Collection of simple workflow plugins and UI modules
 
 ## Templates
-
+https://github.com/madskjeldgaard/Cookiejuce Generate JUCE projects from the command line using cookiecutter. C++20, CMake, CLAP and CPM. Based on Pamplejuce.
 https://github.com/sudara/pamplejuce C++20, JUCE, CMake, Catch2, Pluginval on GitHub Actions
 https://github.com/eyalamirmusic/JUCECmakeRepoPrototype Large variety of JUCE and CMake plugin and app templates
 https://github.com/maxwellpollack/juce-plugin-ci (Archived) CI for JUCE audio plugins with GitHub Actions


### PR DESCRIPTION
Hi! This adds a link to the Cookiejuce template for generating juce projects. Thanks for your awesome work!

Add your repo! 

To get it merged quickly, please check:

* [x] You modified sites.txt, not README.md (which is auto-generated each night)
* [x] You provided the full url, ala `https://github.com/myname/myrepo` with no trailing slash at the end of the url
* [x] The description is short n' sweet
* [x] There's no period on the end of the description
* [x] You didn't add extra newlines

You can add a gitlab or other url, but only github repositories currently show stars and licenses.
