### PR TITLE
Add FreeEQ8 — free 8-band parametric EQ with linear phase, dynamic EQ, match EQ, drive & band linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ I make more JUCEy content over at https://melatonin.dev/blog
 |[DawDreamer](https://github.com/DBraun/DawDreamer) <br/> <sup>by [DBraun](https://github.com/DBraun)</sup> | Python DAW with full cross platform support| GPL-3.0|1167|20 days<sub><sup>󠀠󠀠🟢</sup></sub>|
 |[OwlPlug](https://github.com/DropSnorz/OwlPlug) <br/> <sup>by [DropSnorz](https://github.com/DropSnorz)</sup> | Cross-platform plugin manager| GPL-3.0|441|3 days<sub><sup>󠀠󠀠🟢</sup></sub>|
 |[RenderMan](https://github.com/fedden/RenderMan) <br/> <sup>by [fedden](https://github.com/fedden)</sup> | Interactive "command line" host backed by Maximilian| Unlicense|395| 4 years<sub><sup>🔴</sup></sub>|
+|[FreeEQ8](https://github.com/GareBear99/FreeEQ8) <br/> <sup>by [GareBear99](https://github.com/GareBear99)</sup> | 8-band parametric EQ plugin built with JUCE, featuring linear phase, dynamic EQ, match EQ, per-band drive, band linking, and VST3/AU support| GPL-3.0| | |
 |[Plugalyzer](https://github.com/CrushedPixel/Plugalyzer) <br/> <sup>by [CrushedPixel](https://github.com/CrushedPixel)</sup> | Command-line VST3, AU and LADSPA plugin host for easier debugging of audio plugins| GPL-3.0|157| 1 year<sub><sup>🟠</sup></sub>|
 |[PluginRunner](https://github.com/jatinchowdhury18/PluginRunner) <br/> <sup>by [jatinchowdhury18](https://github.com/jatinchowdhury18)</sup> | Run audio through a plugin from the CLI on windows| WTFPL|14| 6 years<sub><sup>🔴</sup></sub>|
 
@@ -430,4 +431,4 @@ I make more JUCEy content over at https://melatonin.dev/blog
 |[juce_emscripten](https://github.com/Casperaki/juce_emscripten) <br/> <sup>by [Casperaki](https://github.com/Casperaki)</sup> | Port of JUCE for the browser via Emscripten (maintained)| other|9| 3 years<sub><sup>🔴</sup></sub>|
 
 
-293 entries as of 2026-02-26
+294 entries as of 2026-02-26

--- a/sites.txt
+++ b/sites.txt
@@ -139,6 +139,7 @@ https://github.com/unplugred/vsts A treasure trove of effects and other fun plug
 https://github.com/ZL-Audio/ZLEComp Compressor plugin with gain reduction history
 https://github.com/ArdenButterfield/Maim Audio plugin for custom MP3 distortion and digital glitches
 https://github.com/ZL-Audio/ZLEqualizer 16-band minimum-phase dynamic equalizer
+https://github.com/GareBear99/FreeEQ8 8-band parametric EQ with linear phase, dynamic EQ, match EQ, per-band drive and band linking
 https://github.com/tote-bag-labs/valentine An open source compressor meant to pump and breathe
 https://github.com/m1m0zzz/utility-clone VST plugin like a Ableton Utility
 https://git.iem.at/audioplugins/IEMPluginSuite Large suite of plugins, including Ambisonic


### PR DESCRIPTION
## FreeEQ8

**Repository:** https://github.com/GareBear99/FreeEQ8
**License:** GPL-3.0
**Description:** 8-band parametric EQ with linear phase, dynamic EQ, match EQ, per-band drive and band linking

### Why it belongs on awesome-juce
- Built with JUCE 7.0.12, CMake build system
- Full-featured EQ: 6 filter types, 3 slopes (12/24/48 dB/oct), cascaded biquads
- Linear phase mode (4096-tap FIR, overlap-add FFT convolution)
- Dynamic EQ with per-band envelope follower
- Match EQ (reference capture + FFT-based correction)
- Per-band tanh saturation/drive — unique among free EQs
- Band linking (groups A/B)
- Mid/Side processing, oversampling (1×–8×)
- Real-t- Real-t- Real-t- Real-t- Real-t- Real-t- Real-t- Real-t- Real-t- Real-t- Real-t- Real-t- Real-t-e
- VST3 + AU, macOS (10.15+) + Window- VST3 + AU, macOS ent, v1.0.0 released with CI-built binaries (DMG + ZIP)

Co-Authored-By: Oz <oz-agent@warp.dev>