### PR TITLE
Add FreeEQ8

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -142,6 +142,7 @@ https://github.com/ZL-Audio/ZLEqualizer 16-band minimum-phase dynamic equalizer
 https://github.com/tote-bag-labs/valentine An open source compressor meant to pump and breathe
 https://github.com/m1m0zzz/utility-clone VST plugin like a Ableton Utility
 https://git.iem.at/audioplugins/IEMPluginSuite Large suite of plugins, including Ambisonic
+https://github.com/GareBear99/FreeEQ8 8-band parametric EQ with linear phase, dynamic EQ and match EQ
 
 ## Metering 
 


### PR DESCRIPTION
Adds FreeEQ8 as a concise JUCE plugin entry, following the requested format.

Repository: https://github.com/GareBear99/FreeEQ8