### PR TITLE
Add FreeEQ8

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -143,6 +143,7 @@ https://github.com/tote-bag-labs/valentine An open source compressor meant to pu
 https://github.com/m1m0zzz/utility-clone VST plugin like a Ableton Utility
 https://git.iem.at/audioplugins/IEMPluginSuite Large suite of plugins, including Ambisonic
 
+https://github.com/GareBear99/FreeEQ8 Open-source 8-band EQ plugin built with JUCE
 ## Metering 
 
 https://github.com/ffAudio/Frequalizer Equalizer using JUCE's dsp module


### PR DESCRIPTION
Adds FreeEQ8 to sites.txt as requested.

FreeEQ8 is an open-source 8-band EQ plugin built with JUCE.

Repository: https://github.com/GareBear99/FreeEQ8