### PR TITLE
Add montagem-finisher

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -142,6 +142,7 @@ https://github.com/ZL-Audio/ZLEqualizer 16-band minimum-phase dynamic equalizer
 https://github.com/tote-bag-labs/valentine An open source compressor meant to pump and breathe
 https://github.com/m1m0zzz/utility-clone VST plugin like a Ableton Utility
 https://git.iem.at/audioplugins/IEMPluginSuite Large suite of plugins, including Ambisonic
+https://github.com/nabsei/montagem-finisher One-knob genre finisher, entry point to a 5-plugin Montagem chain for funk automotivo & phonk
 
 ## Metering 
 


### PR DESCRIPTION
Add your repo!

To get it merged quickly, please check:

- [x] You modified sites.txt, not README.md (which is auto-generated each night)
- [x] You provided the full url, ala `https://github.com/myname/myrepo` with no trailing slash at the end of the url
- [x] The description is short n' sweet
- [x] There's no period on the end of the description
- [x] You didn't add extra newlines

[montagem-finisher](https://github.com/nabsei/montagem-finisher) is a one-knob genre finisher plugin (VST3/AU/Standalone) for funk automotivo & phonk producers. It's also the entry point to a small 5-plugin chain (808 synth, transient shaper, stereo widener, finisher, and a phase-cancellation checker), all built with JUCE.