### PR TITLE
Add Pakku multiband transient shaper

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -141,6 +141,7 @@ https://github.com/ArdenButterfield/Maim Audio plugin for custom MP3 distortion 
 https://github.com/ZL-Audio/ZLEqualizer 16-band minimum-phase dynamic equalizer
 https://github.com/tote-bag-labs/valentine An open source compressor meant to pump and breathe
 https://github.com/m1m0zzz/utility-clone VST plugin like a Ableton Utility
+https://github.com/danielalves96/pakku-vst Multiband transient shaper with three-band and full-range processing
 https://git.iem.at/audioplugins/IEMPluginSuite Large suite of plugins, including Ambisonic
 
 ## Metering 


### PR DESCRIPTION
Adds Pakku to the Effects section. It is a free, AGPL-3.0 multiband transient shaper built with JUCE and C++20. I am the project author.

Project links:
- Website: https://danielalves96.github.io/pakku-vst/
- Source: https://github.com/danielalves96/pakku-vst
- macOS: https://danielalves96.github.io/pakku-vst/downloads/Pakku-1.0.0-macOS.zip
- Windows: https://danielalves96.github.io/pakku-vst/downloads/Pakku-1.0.0-Windows.zip
- Manual: https://danielalves96.github.io/pakku-vst/manual.pdf

Checklist:
- [x] Modified sites.txt only
- [x] Used a full GitHub URL without a trailing slash
- [x] Kept the description concise
- [x] Omitted terminal punctuation
- [x] Added no extra blank lines